### PR TITLE
remove Z from time formatting

### DIFF
--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -23,11 +23,11 @@ function journal_init(tsks)
     end
     journal
 end
-journal_start!(journal, tsk; pid, hostname) = push!(journal[tsk], Dict("pid"=>pid, "hostname"=>hostname, "start"=>Dates.format(now(Dates.UTC), "yyyy-mm-ddTHH:MM:SSZ")))
+journal_start!(journal, tsk; pid, hostname) = push!(journal[tsk], Dict("pid"=>pid, "hostname"=>hostname, "start"=>Dates.format(now(Dates.UTC), "yyyy-mm-ddTHH:MM:SS")))
 
 function journal_stop!(journal, tsk; fault)
     journal[tsk][end]["status"] = fault ? "failed" : "succeeded"
-    journal[tsk][end]["stop"] = Dates.format(now(Dates.UTC), "yyyy-mm-ddTHH:MM:SSZ")
+    journal[tsk][end]["stop"] = Dates.format(now(Dates.UTC), "yyyy-mm-ddTHH:MM:SS")
 end
 
 function load_modules_on_new_workers(pid)


### PR DESCRIPTION
This works-a-round a failure.  I haven't dug into the reason for the failure, but for the record here is the error stack that this PR is working around...

```
type DateTime has no field zone
│ Stacktrace:
│   [1] getproperty(x::Dates.DateTime, f::Symbol)
│     @ Base ./Base.jl:33
│   [2] format(io::IOBuffer, d::Dates.DatePart{'Z'}, zdt::Dates.DateTime, locale::Dates.DateLocale)
│     @ TimeZones ~/.julia/packages/TimeZones/hCVio/src/parse.jl:81
│   [3] macro expansion
│     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:542 [inlined]
│   [4] format(io::IOBuffer, dt::Dates.DateTime, fmt::Dates.DateFormat{Symbol("yyyy-mm-ddTHH:MM:SSZ"), Tuple{Dates.DatePart{'y'}, Dates.Delim{Char, 1}, Dates.DatePart{'m'}, Dates.Delim{Char, 1}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.Delim{Char, 1}, Dates.DatePart{'M'}, Dates.Delim{Char, 1}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}})
│     @ Dates /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:537
│   [5] format(dt::Dates.DateTime, fmt::Dates.DateFormat{Symbol("yyyy-mm-ddTHH:MM:SSZ"), Tuple{Dates.DatePart{'y'}, Dates.Delim{Char, 1}, Dates.DatePart{'m'}, Dates.Delim{Char, 1}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.Delim{Char, 1}, Dates.DatePart{'M'}, Dates.Delim{Char, 1}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}}, bufsize::Int64)
│     @ Dates /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:549
│   [6] format(dt::Dates.DateTime, fmt::Dates.DateFormat{Symbol("yyyy-mm-ddTHH:MM:SSZ"), Tuple{Dates.DatePart{'y'}, Dates.Delim{Char, 1}, Dates.DatePart{'m'}, Dates.Delim{Char, 1}, Dates.DatePart{'d'}, Dates.Delim{Char, 1}, Dates.DatePart{'H'}, Dates.Delim{Char, 1}, Dates.DatePart{'M'}, Dates.Delim{Char, 1}, Dates.DatePart{'S'}, Dates.DatePart{'Z'}}})
│     @ Dates /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:548
│   [7] format(dt::Dates.DateTime, f::String; locale::Dates.DateLocale)
│     @ Dates /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:588
│   [8] format
│     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/io.jl:588 [inlined]
│   [9] journal_start!(journal::Dict{Any, Any}, tsk::CartesianIndex{1}; pid::Int64, hostname::String)
│     @ Schedulers ~/.julia/dev/Schedulers/src/Schedulers.jl:26
```

