### PR TITLE
Rethrow errors

### DIFF
--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -166,6 +166,7 @@ function load_modules_on_new_workers(pid)
             end
         catch e
             @debug "caught error in load_modules_on_new_workers"
+            throw(e)
         end
     end
     nothing
@@ -185,6 +186,7 @@ function load_functions_on_new_workers(pid)
             if _name ∉ (Symbol("@enter"), Symbol("@run"), :ans, :vscodedisplay)
                 @debug "caught error in load_functions_on_new_workers for function $_name"
             end
+            throw(e)
         end
     end
 end


### PR DESCRIPTION
This should enable the error handling in the elastic loop to function correctly when there is a failure to send functions/modules to workers.