### PR TITLE
add timeouts to all of the remotecall waits/fetches

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -31,9 +31,11 @@ addprocs(5)
     @info "sleeping for task $tsk on worker $(myid()) for 60 seconds"
     sleep(60)
 end
-x = epmapreduce!(zeros(Float64,5), foo, 1:10) # x=[10,10,10,10,10]
+x,tsks = epmapreduce!(zeros(Float64,5), foo, 1:10) # x=[10,10,10,10,10]
 ```
 Note that `y` contains a partial reduction for the tasks assigned to its Julia process.
+`x` is the result, and `tsks` is a list of any tasks that were aborted.  In general, we
+should expect this to be an empty list.
 
 ## Parallel map reduce with structured data
 By default the reduction assumes that the object being reduced is a Julia array.
@@ -59,7 +61,7 @@ end
     nothing
 end
 options = SchedulerOptions(zeros = my_zeros, reducer! = my_reducer!)
-x = epmapreduce!(my_zeros(), options, foo, 1:10)
+x,tsks = epmapreduce!(my_zeros(), options, foo, 1:10)
 ```
 
 ## Parameterization

--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -358,12 +358,15 @@ end
 
 function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_reduce)
     polling_interval = parse(Int, get(ENV, "SCHEDULERS_POLLING_INTERVAL", "1"))
-    init_tasks = Dict{Int,Task}()
-
-    bad_pids = Set{Int}()
-    wrkrs = Dict{Int, Union{Distributed.LocalProcess, Distributed.Worker}}()
+    addrmprocs_timeout = parse(Int, get(ENV, "SCHEDULERS_ADDRMPROCS_TIMEOUT", "60"))
 
     tsk_addrmprocs = @async nothing
+    tsk_addrmprocs_interrupt = @async nothing
+    tsk_addrmprocs_tic = time()
+
+    initializing_pids = Set{Int}()
+    bad_pids = Set{Int}()
+    wrkrs = Dict{Int, Union{Distributed.LocalProcess, Distributed.Worker}}()
 
     is_tasks_done_message_sent = false
     is_reduce_done_message_sent = false
@@ -436,70 +439,72 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
             continue
         end
 
-        new_pids = filter(pid->(pid ∉ eloop.used_pids && pid ∉ bad_pids), workers())
+        uninitialized_pids = filter(pid->(pid ∉ initializing_pids && pid ∉ eloop.initialized_pids), workers())
 
-        @debug "workers()=$(workers()), new_pids=$new_pids, used_pids=$(eloop.used_pids), bad_pids=$bad_pids"
+        for uninitialized_pid in uninitialized_pids
+            if !haskey(Distributed.map_pid_wrkr, uninitialized_pid)
+                @warn "worker with pid=$uninitialized_pid is not registered"
+            else
+                wrkrs[uninitialized_pid] = Distributed.map_pid_wrkr[uninitialized_pid]
+                push!(initializing_pids, uninitialized_pid)
+                @async try
+                    @debug "initializing failure count on $uninitialized_pid"
+                    yield()
+                    eloop.pid_failures[uninitialized_pid] = 0
+                    @debug "loading modules on $uninitialized_pid"
+                    yield()
+                    load_modules_on_new_workers(uninitialized_pid)
+                    @debug "loading functions on $uninitialized_pid"
+                    yield()
+                    load_functions_on_new_workers(uninitialized_pid)
+                    @debug "calling init on new $uninitialized_pid"
+                    yield()
+                    eloop.epmap_init(uninitialized_pid)
+                    @debug "done loading functions modules, and calling init on $uninitialized_pid"
+                    yield()
+                    _pid_up_timestamp[uninitialized_pid] = time()
+                    push!(eloop.initialized_pids, uninitialized_pid)
+                    pop!(initializing_pids, uninitialized_pid)
+                catch e
+                    @warn "problem initializing $uninitialized_pid, removing $uninitialized_pid from cluster."
+                    logerror(e, Logging.Warn)
+                    uninitialized_pid ∈ eloop.initialized_pids && pop!(eloop.initialized_pids, uninitialized_pid)
+                    uninitialized_pid ∈ initializing_pids && pop!(initializing_pids, uninitialized_pid)
+                    haskey(eloop.pid_failures, uninitialized_pid) && pop!(eloop.pid_failures, uninitialized_pid)
+                    push!(bad_pids, uninitialized_pid)
+                end
+            end
+        end
+
+        free_pids = filter(pid->(pid ∈ eloop.initialized_pids && pid ∉ eloop.used_pids && pid ∉ bad_pids), workers())
+
+        @debug "workers()=$(workers()), free_pids=$free_pids, used_pids=$(eloop.used_pids), bad_pids=$bad_pids, initialized_pids=$(eloop.initialized_pids)"
         yield()
 
         @debug "checking for reduction trigger"
         reduce_trigger(eloop, journal, journal_task_callback)
         @debug "trigger=$(eloop.is_reduce_triggered)"
 
-        for new_pid in new_pids
-            push!(eloop.used_pids, new_pid)
-            init_tasks[new_pid] = @async begin
-                try
-                    if new_pid ∉ eloop.initialized_pids
-                        @debug "initializing failure count on $new_pid"
-                        yield()
-                        eloop.pid_failures[new_pid] = 0
-                        @debug "loading modules on $new_pid"
-                        yield()
-                        load_modules_on_new_workers(new_pid)
-                        @debug "loading functions on $new_pid"
-                        yield()
-                        load_functions_on_new_workers(new_pid)
-                        @debug "calling init on new $new_pid"
-                        yield()
-                        eloop.epmap_init(new_pid)
-                        @debug "done loading functions modules, and calling init on $new_pid"
-                        yield()
-                        _pid_up_timestamp[new_pid] = time()
-                        push!(eloop.initialized_pids, new_pid)
-                    end
+        for free_pid in free_pids
+            push!(eloop.used_pids, free_pid)
 
-                    if !haskey(Distributed.map_pid_wrkr, new_pid)
-                        @warn "worker with pid=$new_pid is not registered"
-                        new_pid ∈ keys(wrkrs) && pop!(wrkrs, new_pid)
-                        new_pid ∈ eloop.used_pids && pop!(eloop.used_pids, new_pid)
-                    else
-                        wrkrs[new_pid] = Distributed.map_pid_wrkr[new_pid]
+            if eloop.is_reduce_triggered && !(eloop.checkpoints_are_flushed) && length(eloop.checkpoints) == 0
+                eloop.reduce_checkpoints_snapshot = copy(eloop.reduce_checkpoints)
+                eloop.checkpoints_are_flushed = true
+            end
 
-                        if eloop.is_reduce_triggered && !(eloop.checkpoints_are_flushed) && length(eloop.checkpoints) == 0
-                            eloop.reduce_checkpoints_snapshot = copy(eloop.reduce_checkpoints)
-                            eloop.checkpoints_are_flushed = true
-                        end
+            is_waiting_on_flush = eloop.is_reduce_triggered && !(eloop.checkpoints_are_flushed)
+            @debug "is_reduce_triggered=$(eloop.is_reduce_triggered), checkpoints_are_flushed=$(eloop.checkpoints_are_flushed), is_waiting_on_flush=$is_waiting_on_flush, reduce_machine_count=$(eloop.reduce_machine_count)"
 
-                        is_waiting_on_flush = eloop.is_reduce_triggered && !(eloop.checkpoints_are_flushed)
-                        @debug "is_reduce_triggered=$(eloop.is_reduce_triggered), checkpoints_are_flushed=$(eloop.checkpoints_are_flushed), is_waiting_on_flush=$is_waiting_on_flush, reduce_machine_count=$(eloop.reduce_machine_count)"
-
-                        if is_more_tasks && !is_waiting_on_flush && div(length(eloop.reduce_checkpoints_snapshot), 2) <= eloop.reduce_machine_count
-                            @debug "putting pid=$new_pid onto map channel"
-                            put!(eloop.pid_channel_map_add, new_pid)
-                        elseif is_more_checkpoints && !is_waiting_on_flush && div(length(eloop.reduce_checkpoints), 2) > eloop.reduce_machine_count
-                            @debug "putting pid=$new_pid onto reduce channel"
-                            put!(eloop.pid_channel_reduce_add, new_pid)
-                            eloop.reduce_machine_count += 1
-                        else
-                            new_pid ∈ eloop.used_pids && pop!(eloop.used_pids, new_pid)
-                        end
-                    end
-                catch e
-                    @warn "problem initializing $new_pid, removing $new_pid from cluster."
-                    logerror(e, Logging.Warn)
-                    push!(bad_pids, new_pid)
-                    new_pid ∈ eloop.used_pids && pop!(eloop.used_pids, new_pid)
-                end
+            if is_more_tasks && !is_waiting_on_flush && div(length(eloop.reduce_checkpoints_snapshot), 2) <= eloop.reduce_machine_count
+                @debug "putting pid=$free_pid onto map channel"
+                put!(eloop.pid_channel_map_add, free_pid)
+            elseif is_more_checkpoints && !is_waiting_on_flush && div(length(eloop.reduce_checkpoints), 2) > eloop.reduce_machine_count
+                @debug "putting pid=$free_pid onto reduce channel"
+                put!(eloop.pid_channel_reduce_add, free_pid)
+                eloop.reduce_machine_count += 1
+            else
+                free_pid ∈ eloop.used_pids && pop!(eloop.used_pids, free_pid)
             end
         end
 
@@ -520,56 +525,65 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
 
         @debug "add at most $_epmap_quantum machines when there are less than $_epmap_maxworkers, and there are less then the current task count: $n_remaining_tasks (δ=$δ, n=$_epmap_nworkers)"
         @debug "remove machine when there are more than $_epmap_minworkers, and less tasks ($n_remaining_tasks) than workers ($_epmap_nworkers), and when those workers are free (currently there are $_epmap_nworkers workers, and $(length(eloop.used_pids)) busy procs inclusive of process 1)"
+
         if istaskdone(tsk_addrmprocs)
-            tsk_addrmprocs = @async begin
-                if !isempty(bad_pids)
-                    @debug "removing bad pids: $bad_pids"
-                    while !isempty(bad_pids)
-                        bad_pid = pop!(bad_pids)
-                        if haskey(Distributed.map_pid_wrkr, bad_pid)
-                            @debug "bad pid=$bad_pid is known to Distributed, calling rmprocs"
-                            rmprocs(bad_pid)
-                        else
-                            @debug "bad pid=$bad_pid is not known to Distributed, calling kill"
+            if δ < 0 || length(bad_pids) > 0
+                rm_pids = Int[]
+                while !isempty(bad_pids)
+                    push!(rm_pids, pop!(bad_pids))
+                end
+                δ += length(rm_pids)
+                if istaskdone(tsk_addrmprocs)
+                    tsk_addrmprocs = @async begin
+                        if δ < 0
+                            free_pids = filter(pid->pid ∉ eloop.used_pids, workers())
+                            push!(rm_pids, free_pids[1:min(-δ, length(free_pids))]...)
+                        end
+                        rm_pids_known = filter(rm_pid->haskey(Distributed.map_pid_wrkr, rm_pid), rm_pids)
+                        rm_pids_unknown = filter(rm_pid->rm_pid ∉ rm_pids_known, rm_pids)
+
+                        @debug "calling rmprocs on $rm_pids_known"
+                        try
+                            rmprocs(rm_pids_known; waitfor=addrmprocs_timeout)
+                        catch e
+                            @warn "unable to run rmprocs on $rm_pids_known in $addrmprocs_timeout seconds."
+                            logerror(e, Logging.Warn)
+                        end
+                        @debug "done calling rmprocs on known pids"
+
+                        for rm_pid in rm_pids_unknown
+                            @debug "pid=$rm_pid is not known to Distributed, calling kill"
                             try
                                 # required for cluster managers that require clean-up when the julia process on a worker dies:
-                                Distributed.kill(wrkrs[bad_pid].manager, bad_pid, wrkrs[bad_pid].config)
+                                @debug "calling kill with pid=$rm_pid"
+                                Distributed.kill(wrkrs[rm_pid].manager, rm_pid, wrkrs[rm_pid].config)
+                                @debug "done calling kill with pid=$rm_pid"
                             catch e
-                                @warn "unable to kill bad worker with pid=$bad_pid"
+                                @warn "unable to kill bad worker with pid=$rm_pid"
                                 logerror(e, Logging.Warn)
                             end
                         end
-                        bad_pid ∈ wrkrs && delete!(wrkrs, bad_pid)
-                    end
-                elseif δ > 0
-                    try
-                        @debug "adding $δ procs"
-                        eloop.epmap_addprocs(δ)
-                    catch e
-                        @error "problem adding new processes"
-                        logerror(e, Logging.Error)
-                    end
-                elseif δ < 0
-                    @debug "determining free pids"
-                    freepids = filter(pid->pid ∉ eloop.used_pids, workers())
-                    @debug "done determining free pids"
 
-                    @debug "push onto rmpids"
-                    rmpids = freepids[1:min(-δ, length(freepids))]
-                    @debug "done push onto rmpids"
-
-                    try
-                        @debug "removing $rmpids from $freepids"
-                        rmprocs(rmpids)
-                    catch e
-                        @error "problem removing old processes"
-                        logerror(e, Logging.Error)
+                        for rm_pid in rm_pids
+                            haskey(wrkrs, rm_pid) && delete!(wrkrs, rm_pid)
+                        end
                     end
                 end
-                @debug "done making new async add/rmprocs"
+            elseif δ > 0
+                try
+                    @debug "adding $δ procs"
+                    tsk_addrmprocs_tic = time()
+                    tsk_addrmprocs = @async eloop.epmap_addprocs(δ)
+                catch e
+                    @error "problem adding new processes"
+                    logerror(e, Logging.Error)
+                end
             end
-        else
-            @debug "previous addprocs/rmprocs is not complete, expect delays."
+
+            tsk_addrmprocs_tic = time()
+        elseif time() - tsk_addrmprocs_tic > addrmprocs_timeout && istaskdone(tsk_addrmprocs_interrupt)
+            @warn "addprocs/rmprocs taking longer than expected, cancelling."
+            tsk_addrmprocs_interrupt = @async Base.throwto(tsk_addrmmprocs, InterruptException())
         end
 
         @debug "checking for workers sent from the map"
@@ -579,7 +593,6 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
                 pid,isbad = take!(eloop.pid_channel_map_remove)
                 @debug "map channel, received pid=$pid, making sure that it is initialized"
                 yield()
-                wait(init_tasks[pid])
                 isbad && push!(bad_pids, pid)
                 @debug "map channel, $pid is initialized, removing from used_pids"
                 pid ∈ eloop.used_pids && pop!(eloop.used_pids, pid)
@@ -587,7 +600,7 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
             end
         catch e
             @warn "problem in Schedulers.jl elastic loop when removing workers from map"
-            logerror(e)
+            logerror(e, Logging.Warn)
         end
 
         @debug "checking for workers sent from the reduce"
@@ -598,7 +611,6 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
                 eloop.reduce_machine_count -= 1
                 @debug "reduce channel, received pid=$pid (isbad=$isbad), making sure that it is initialized"
                 yield()
-                wait(init_tasks[pid])
                 isbad && push!(bad_pids, pid)
                 @debug "reduce_channel, $pid is initialied, removing from used_pids"
                 pid ∈ eloop.used_pids && pop!(eloop.used_pids, pid)
@@ -614,18 +626,9 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
     end
     @debug "exited the elastic loop"
 
-    @debug "ensure that tsk_addrmprocs is done."
-    tic = time()
-    while !istaskdone(tsk_addrmprocs)
-        if time() - tic > 10
-            @warn "delayed remove/add procs tasks took longer than 10 seconds, giving up..."
-            # try
-            #     Base.throwto(tsk_addrmprocs, ErrorException(""))
-            # catch
-            # end
-            break
-        end
-        sleep(1)
+    @debug "cancel any pending add/rm procs tasks"
+    if !istaskdone(tsk_addrmprocs)
+        @async Base.throwto(_tsk, InterruptException())
     end
 
     # ensure we are left with epmap_minworkers
@@ -811,17 +814,20 @@ function epmap_map(options::SchedulerOptions, f::Function, tasks, eloop::Elastic
         @debug "pid=$pid"
         pid == -1 && break # pid=-1 is put onto the channel in the above elastic_loop when tsk_pool_done is full.
 
-        local hostname
-        try
-            hostname = remotecall_fetch(gethostname, pid)
-        catch e
-            @warn "unable to determine hostname for pid=$pid"
-            logerror(e, Logging.Warn)
-            put!(eloop.pid_channel_map_remove, (pid,true))
-            continue
-        end
+        hostname = ""
 
         @async while true
+            if hostname == ""
+                try
+                    hostname = remotecall_fetch(gethostname, pid)
+                catch e
+                    @warn "unable to determine hostname for pid=$pid"
+                    logerror(e, Logging.Warn)
+                    put!(eloop.pid_channel_map_remove, (pid, true))
+                    break
+                end
+            end
+
             is_preempted = check_for_preempted(pid, options.preempted)
             @debug "map task loop exit condition" pid is_preempted length(eloop.tsk_pool_todo) eloop.interrupted
             if is_preempted || length(eloop.tsk_pool_todo) == 0 || eloop.interrupted
@@ -1006,16 +1012,7 @@ function epmapreduce_map(f, results::T, epmap_eloop, epmap_journal, options, arg
             continue
         end
 
-        local hostname
-        try
-            hostname = remotecall_fetch(gethostname, pid)
-        catch e
-            @warn "unable to determine hostname for pid=$pid"
-            logerror(e, Logging.Warn)
-            haskey(localresults, pid) && deleteat!(localresults, pid)
-            put!(epmap_eloop.pid_channel_reduce_remove, (pid,true))
-            continue
-        end
+        hostname = ""
 
         # It is important that this is async in the event that the allocation in options.zeros is large, and takes a significant amount of time.
         # Exceptions will be caught the first time we fetch `localresults[pid]` in the `epmapreduce_fetch_apply` method.
@@ -1024,6 +1021,22 @@ function epmapreduce_map(f, results::T, epmap_eloop, epmap_journal, options, arg
         epmap_eloop.checkpoints[pid] = nothing
 
         @async while true
+            if hostname == ""
+                try
+                    hostname = remotecall_fetch(gethostname, pid)
+                catch e
+                    @warn "unable to determine hostname for pid=$pid"
+                    logerror(e, Logging.Warn)
+                    if epmap_eloop.checkpoints[pid] !== nothing
+                        push!(epmap_eloop.reduce_checkpoints, epmap_eloop.checkpoints[pid])
+                    end
+                    haskey(localresults, pid) && deleteat!(localresults, pid)
+                    pop!(epmap_eloop.checkpoints, pid)
+                    put!(epmap_eloop.pid_channel_reduce_remove, (pid,true))
+                    break
+                end
+            end
+
             @debug "map, pid=$pid, interrupted=$(epmap_eloop.interrupted), isempty(epmap_eloop.tsk_pool_todo)=$(isempty(epmap_eloop.tsk_pool_todo))"
             @debug "epmap_eloop.is_reduce_triggered=$(epmap_eloop.is_reduce_triggered)"
             is_preempted = check_for_preempted(pid, options.preempted)


### PR DESCRIPTION
This adds timeouts for the various remotecall fetches and waits.  The timeout is computed assuming that the operations (e.g. tasks) are uniform in their compute time up to some user supplied multiplier.

For now, this PR abandons tasks that time-out.  I don't think this will be merged as is, but it might be useful to have this branch here for the time being.