### PR TITLE
Keep `SchedulerOptions` the same for `epmapreduce!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Schedulers"
 uuid = "fcb5363a-df8d-57f1-a64b-7615e60d793b"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -1062,7 +1062,9 @@ result,tsks = epmapreduce!(zeros(Float32,10), SchedulerOptions(;reduce_trigger=e
 ```
 Note that the methods `complete_tasks`, `pending_tasks`, `reduced_tasks`, and `total_tasks` can be useful when designing the `reduce_trigger` method.
 """
-function epmapreduce!(result::T, options::SchedulerOptions, f::Function, tasks, args...; kwargs...) where {T}
+function epmapreduce!(result::T, _options::SchedulerOptions, f::Function, tasks, args...; kwargs...) where {T}
+    options = deepcopy(_options)
+
     for scratch in options.scratch
         isdir(scratch) || mkpath(scratch)
     end

--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -1062,8 +1062,8 @@ result,tsks = epmapreduce!(zeros(Float32,10), SchedulerOptions(;reduce_trigger=e
 ```
 Note that the methods `complete_tasks`, `pending_tasks`, `reduced_tasks`, and `total_tasks` can be useful when designing the `reduce_trigger` method.
 """
-function epmapreduce!(result::T, _options::SchedulerOptions, f::Function, tasks, args...; kwargs...) where {T}
-    options = deepcopy(_options)
+function epmapreduce!(result::T, options::SchedulerOptions, f::Function, tasks, args...; kwargs...) where {T}
+    options_init = copy(options)
 
     for scratch in options.scratch
         isdir(scratch) || mkpath(scratch)
@@ -1090,6 +1090,9 @@ function epmapreduce!(result::T, _options::SchedulerOptions, f::Function, tasks,
     journal_final(epmap_journal)
     journal_write(epmap_journal, options.journalfile)
 
+    for fieldname in fieldnames(SchedulerOptions)
+        setfield!(options, fieldname, getfield(options_init, fieldname))
+    end
     result, epmap_eloop.tsk_pool_timed_out
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,9 +303,13 @@ end
 
     a,b = 2,3
     options = SchedulerOptions(;scratch=tmpdir)
+    options_init = deepcopy(options)
     x,tsks = epmapreduce!(zeros(Float32,10), options, foo6, 1:100, a; b=b)
 
     rmprocs(workers())
+    for field ∈ fieldnames(SchedulerOptions)
+        @test getfield(options_init, field) == getfield(options, field)
+    end
     @test x ≈ sum(a*b*[1:100;]) * ones(10)
     @test mapreduce(file->startswith("checkpoint", file), +, ["x";readdir(tmpdir)]) == 0
     rm(tmpdir; recursive=true, force=true)


### PR DESCRIPTION
This PR aims to keep `SchedulerOptions` the same before and after running the `epmapreduce!`. This can be helpful when one wants to keep the same option and run `epmapreduce!` a few times. Minimum test is added in `runtests.jl` and the version number is updated to 0.9.2.