### PR TITLE
fix: rate-limit scale-down to prevent runaway cascade

### DIFF
--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -744,6 +744,12 @@ function loop(eloop::ElasticLoop, journal, journal_task_callback, tsk_map, tsk_r
         try
             n_remaining_tasks = eloop.tsk_count - length(eloop.tsk_pool_done) + max(length(eloop.reduce_checkpoints) - 1, 0)
             δ = min(n_remaining_tasks - _epmap_nworkers, _epmap_maxworkers - _epmap_nworkers, _epmap_quantum)
+            # Rate-limit scale-down: remove at most `quantum` workers per cycle to prevent
+            # a runaway cascade where tasks complete faster than workers can be removed,
+            # collapsing a 700-worker cluster to near-zero in minutes.
+            if δ < 0
+                δ = max(δ, -_epmap_quantum)
+            end
             # note that 1. we will only remove a machine if it is not in the 'eloop.used_pids' vector.
             # and 2. we will only remove machines if we are left with at least epmap_minworkers.
             if _epmap_nworkers + δ < _epmap_minworkers


### PR DESCRIPTION
When remaining_tasks drops below nworkers near the end of a pmap, the scheduler computes a large negative δ and removes hundreds of workers per cycle. Tasks complete faster than rmprocs can execute, so each cycle δ becomes more negative — collapsing a 700-worker cluster to near-zero in minutes (observed in MFWI job 309, iterations 3 and 6, causing 5-hour hangs).

Cap negative δ at -quantum (matching the existing +quantum cap for scale-up) so scale-down is gradual and the cluster remains usable for the remaining tasks.