### PR TITLE
use median timeout 

### DIFF
--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -243,7 +243,7 @@ struct TimeoutException <: Exception
     elapsed::Float64
 end
 
-maximum_task_time(tsk_times, tsk_count, timeout_multiplier) = length(tsk_times) > max(0, floor(Int, 0.5*tsk_count)) ? median(tsk_times)*timeout_multiplier : Inf
+maximum_task_time(tsk_times, tsk_count, timeout_multiplier) = length(tsk_times) > max(0, floor(Int, 0.3*tsk_count)) ? median(tsk_times)*timeout_multiplier : Inf
 
 struct PreemptException <: Exception end
 
@@ -320,11 +320,8 @@ function robust_average(tsk_times, null_tsk_runtime_threshold, tsk_count, tsk, r
     if report
         @debug "calculating robust average for tsk=$tsk, length(tsk_times)=$(length(tsk_times)), length(tsk_times_robust)=$(length(tsk_times_robust)), tsk_count=$tsk_count, null_tsk_runtime_threshold=$null_tsk_runtime_threshold, tsk_times=$(my_extrema(tsk_times)), tsk_times_robust=$(my_extrema(tsk_times_robust))"
     end
-    if length(tsk_times_robust) >= 0.3 * tsk_count     # Start statistics after 30% of the tasks are done
-        return sum(tsk_times_robust) / length(tsk_times_robust)
-    else
-        return Inf
-    end
+
+    length(tsk_times_robust) >= 0.3 * tsk_count ? median(tsk_times_robust) : Inf
 end
 
 function check_timeout_status(tic, tsk_times, tsk_count, timeout_function_multiplier, grace_period_start_time, null_tsk_runtime_threshold, grace_period_ratio, tsk, report)

--- a/src/Schedulers.jl
+++ b/src/Schedulers.jl
@@ -1036,11 +1036,11 @@ and `pmap_kwargs` are as follows.
 ## epmap_kwargs
 * `retries=0` number of times to retry a task on a given machine before removing that machine from the cluster
 * `maxerrors=typemax(Int)` the maximum number of errors before we give-up and exit
-* `timeout_multiplier=5` if any (miscellaneous) task takes `timeout_multiplier` longer than the mean (miscellaneous) task time, then abort that task
-* `timeout_function_multiplier=5` if any (actual) task takes `timeout_function_multiplier` longer than the (robust) mean (actual) task time, then abort that task
+* `timeout_multiplier=5` if any (miscellaneous) task takes `timeout_multiplier` longer than the median (miscellaneous) task time, then abort that task
+* `timeout_function_multiplier=5` if any (actual) task takes `timeout_function_multiplier` longer than the (robust) median (actual) task time, then abort that task
 * `null_tsk_runtime_threshold=0` the maximum duration (in seconds) for a task to be considered insignificant or ‘null’ and thus not included in the timeout measurement.
 * `skip_tsk_tol_ratio=0` the ratio of the total number of tasks that can be skipped
-* `grace_period_ratio=0` the ratio between the "grace period" (when enough number of tasks are done) over the (robust) average task time
+* `grace_period_ratio=0` the ratio between the "grace period" (when enough number of tasks are done) over the (robust) median task time
 * `skip_tasks_that_timeout=false` skip task that exceed the timeout, or retry them on a different machine
 * `minworkers=Distributed.nworkers` method (or value) giving the minimum number of workers to elastically shrink to
 * `maxworkers=Distributed.nworkers` method (or value) giving the maximum number of workers to elastically expand to
@@ -1186,11 +1186,11 @@ and `epmap_kwargs` are as follows.
 * `zeros = ()->zeros(eltype(result), size(result))` the method used to initialize partial reductions
 * `retries=0` number of times to retry a task on a given machine before removing that machine from the cluster
 * `maxerrors=Inf` the maximum number of errors before we give-up and exit
-* `timeout_multiplier=5` if any (miscellaneous) task takes `timeout_multiplier` longer than the mean (miscellaneous) task time, then abort that task
-* `timeout_function_multiplier=5` if any (actual) task takes `timeout_function_multiplier` longer than the (robust) mean (actual) task time, then abort that task
+* `timeout_multiplier=5` if any (miscellaneous) task takes `timeout_multiplier` longer than the median (miscellaneous) task time, then abort that task
+* `timeout_function_multiplier=5` if any (actual) task takes `timeout_function_multiplier` longer than the (robust) median (actual) task time, then abort that task
 * `null_tsk_runtime_threshold=0` the maximum duration (in seconds) for a task to be considered insignificant or ‘null’ and thus not included in the timeout measurement.
 * `skip_tsk_tol_ratio=0` the ratio of the total number of tasks that can be skipped
-* `grace_period_ratio=0` the ratio between the "grace period" (when enough number of tasks are done) over the (robust) average task time
+* `grace_period_ratio=0` the ratio between the "grace period" (when enough number of tasks are done) over the (robust) median task time
 * `skip_tasks_that_timeout=false` skip task that exceed the timeout, or retry them on a different machine
 * `minworkers=nworkers` method giving the minimum number of workers to elastically shrink to
 * `maxworkers=nworkers` method giving the maximum number of workers to elastically expand to


### PR DESCRIPTION

The current `robust_average` computes a straight mean, tasks stuck on dead workers (killed during scale-down) wait a long time before being resubmitted.

Fix: 
- use median instead of mean in robust_average. The median is resistant to long-tail outliers that inflate the mean. With task times of large variability, the median converges to the typical task duration faster than the mean, producing tighter timeouts.

~Builds on
 `wask/delta-floor` (PR #138) — rate-limits scale-down to prevent runaway cascade~

~question: is 30 min a reasonable default initial timeout?~
